### PR TITLE
Hide document access fields from non-owners

### DIFF
--- a/client/components/documents/DocumentForm.js
+++ b/client/components/documents/DocumentForm.js
@@ -32,34 +32,42 @@ const DocumentForm = props => (
               error={props.errors.content}
             />
           </Cell>
-          <Cell col={6}>
-            <label htmlFor="read-access" className={getTextColorClass('teal')}>
-              Who can read?
-            </label>
-            <select
-              required
-              id="read-access"
-              onChange={props.onFieldChange('readAccess')}
-              defaultValue={props.values.readAccess || 'public'}>
-              <option value="public">Public</option>
-              <option value="authenticated">Logged In Users</option>
-              <option value="private">Only Me</option>
-            </select>
-          </Cell>
-          <Cell col={6}>
-            <label htmlFor="write-access" className={getTextColorClass('teal')}>
-              Who can edit?
-            </label>
-            <select
-              required
-              id="write-access"
-              onChange={props.onFieldChange('writeAccess')}
-              defaultValue={props.values.writeAccess || 'private'}>
-              <option value="authenticated">Logged In Users</option>
-              <option value="private">Only Me</option>
-            </select>
-          </Cell>
         </Grid>
+        {props.canEditAccess &&
+          <Grid>
+            <Cell col={6}>
+              <label
+                htmlFor="read-access"
+                className={getTextColorClass('teal')}>
+                Who can read?
+              </label>
+              <select
+                required
+                id="read-access"
+                onChange={props.onFieldChange('readAccess')}
+                defaultValue={props.values.readAccess || 'public'}>
+                <option value="public">Public</option>
+                <option value="authenticated">Logged In Users</option>
+                <option value="private">Only Me</option>
+              </select>
+            </Cell>
+            <Cell col={6}>
+              <label
+                htmlFor="write-access"
+                className={getTextColorClass('teal')}>
+                Who can edit?
+              </label>
+              <select
+                required
+                id="write-access"
+                onChange={props.onFieldChange('writeAccess')}
+                defaultValue={props.values.writeAccess || 'private'}>
+                <option value="authenticated">Logged In Users</option>
+                <option value="private">Only Me</option>
+              </select>
+            </Cell>
+          </Grid>
+        }
       </CardText>
       <CardActions border>
         <Button colored onClick={props.onSubmit}>

--- a/client/containers/util/createDocumentView.js
+++ b/client/containers/util/createDocumentView.js
@@ -58,7 +58,7 @@ export const createDocumentView = Component => {
 
 
     render() {
-      const { doc, canEdit, canDelete } = this.props;
+      const { doc } = this.props;
       if (this.state.isEditing) {
         return (
           <EditDocument
@@ -74,9 +74,7 @@ export const createDocumentView = Component => {
             {...doc}
             onEditClick={this.handleEditStart}
             onDeleteClick={this.handleOpenDeleteDialog}
-            canEdit={canEdit}
-            canDelete={canDelete}
-            {...omit(this.props, ['doc', 'canEdit', 'canDelete'])}
+            {...omit(this.props, 'doc')}
           />
           <Dialog open={this.state.openDeleteDialog}>
             <DialogContent>
@@ -108,6 +106,7 @@ export const createDocumentView = Component => {
     onDeleteSuccess: PropTypes.func.isRequired,
     canEdit: PropTypes.bool,
     canDelete: PropTypes.bool,
+    canEditAccess: PropTypes.bool,
   };
 
   return DocumentView;
@@ -124,10 +123,14 @@ export const mapStateToProps = (state, ownProps) => {
     (doc.owner && doc.owner._id === state.authenticatedUser._id ||
     state.authenticatedUser.role.title === 'admin');
 
+  const canEditAccess = doc && state.authenticatedUser &&
+    doc.owner && doc.owner._id === state.authenticatedUser._id;
+
   return {
     doc,
     canEdit,
     canDelete,
+    canEditAccess,
   };
 };
 

--- a/tests/client/containers/util/CreateDocumentViewSpec.js
+++ b/tests/client/containers/util/CreateDocumentViewSpec.js
@@ -34,6 +34,7 @@ describe('createDocumentView higher-order component', () => {
       doc: { _id: '1' },
       canEdit: true,
       canDelete: true,
+      canEditAccess: true,
     };
     const wrapper = mount(<DocumentView {...props} />);
     const component = wrapper.find(Component);
@@ -49,6 +50,7 @@ describe('createDocumentView higher-order component', () => {
       doc: { _id: '1' },
       canEdit: true,
       canDelete: true,
+      canEditAccess: true,
     };
     const wrapper = mount(<DocumentView {...props} />);
     const component = wrapper.find(Component);
@@ -73,6 +75,7 @@ describe('createDocumentView higher-order component', () => {
       doc: { _id: '1' },
       canEdit: true,
       canDelete: true,
+      canEditAccess: true,
       deleteDocument: sinon.spy(() => Promise.resolve()),
     };
     const wrapper = mount(<DocumentView {...props} />);
@@ -103,6 +106,7 @@ describe('createDocumentView higher-order component', () => {
         doc: ownProps.doc,
         canEdit: true,
         canDelete: true,
+        canEditAccess: true,
       };
       expect(mapStateToProps(state, ownProps)).to.eql(expectedProps);
     });
@@ -118,6 +122,7 @@ describe('createDocumentView higher-order component', () => {
         doc: ownProps.doc,
         canEdit: true,
         canDelete: false,
+        canEditAccess: false,
       };
       expect(mapStateToProps(state, ownProps)).to.eql(expectedProps);
     });
@@ -133,6 +138,7 @@ describe('createDocumentView higher-order component', () => {
         doc: ownProps.doc,
         canEdit: false,
         canDelete: true,
+        canEditAccess: false,
       };
       expect(mapStateToProps(state, ownProps)).to.eql(expectedProps);
     });


### PR DESCRIPTION
Non-owners editing a document should not see  access fields as the
server will ignore that input.